### PR TITLE
fixes for WCOSS Cray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   ufs_util
   VERSION ${pVersion}
   LANGUAGES Fortran)
-
+# LANGUAGES C CXX Fortran)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
@@ -43,8 +43,9 @@ if(NOT NETCDF)
   endif()
 endif()
 find_package(NetCDF MODULE REQUIRED)
-
-find_package(MPI REQUIRED COMPONENTS Fortran)
+#unset(CMAKE_C_COMPILER_LOADED)
+#unset(CMAKE_CXX_COMPILER_LOADED)
+find_package(MPI REQUIRED )
 find_package(ESMF MODULE REQUIRED)
 find_package(WGRIB2 REQUIRED)
 

--- a/sorc/build_chgres_cube.sh
+++ b/sorc/build_chgres_cube.sh
@@ -36,7 +36,11 @@ rm -fr ../build
 mkdir ../build
 cd ../build
 echo $ESMFMKFILE
-cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_INSTALL_PREFIX=../
+if [[ $target == "wcoss_cray" ]]; then
+  /u/Mark.Potts/bin/cmake .. -DCMAKE_INSTALL_PREFIX=../
+else
+  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_INSTALL_PREFIX=../
+fi
 make -j 8 VERBOSE=1
 make install
 exit


### PR DESCRIPTION
This should work on the Cray now, though I currently have CMake hard-coded to be the new cmake I have in /u/Mark.Potts/bin. If there is a new version of CMake somewhere on the Cray, we need to change to that, or have a new version installed. Also, I had to modify the "--has-parallel" and "--has-parallel4" in the new FindNetCDF.cmake module to "--has-pnetcdf". I am not sure that will work for other platforms, so we may have to look into that a bit more. 