### PR TITLE
CMake fixes

### DIFF
--- a/sorc/fre-nctools.fd/shared_lib/CMakeLists.txt
+++ b/sorc/fre-nctools.fd/shared_lib/CMakeLists.txt
@@ -11,27 +11,21 @@ set(c_src
     read_mosaic.c
     tool_util.c)
 
-add_definitions(-Duse_netCDF)
-
 if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_C_FLAGS "-traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2")
-  set(CMAKE_C_FLAGS_DEBUG
-      "-O0"
-  )
+  set(CMAKE_C_FLAGS_DEBUG "-O0")
 elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_C_FLAGS " ")
   set(CMAKE_C_FLAGS_RELEASE " ")
-  set(CMAKE_C_FLAGS_DEBUG " "
-  )
+  set(CMAKE_C_FLAGS_DEBUG " ")
 endif()
 
-set(lib_name shared_all)
-add_library(${lib_name} STATIC ${c_src})
-target_include_directories(
-  ${lib_name} PRIVATE)
-target_link_libraries(
-  ${lib_name}
-  NetCDF::NetCDF_C)
+add_library(shared_all STATIC ${c_src})
+target_compile_definitions(shared_all PRIVATE use_netCDF)
 
-install(TARGETS ${lib_name} RUNTIME DESTINATION ./)
+target_include_directories(shared_all PUBLIC ${CURRENT_SOURCE_DIR})
+
+target_link_libraries(shared_all NetCDF::NetCDF_C)
+
+install(TARGETS shared_all RUNTIME DESTINATION lib)

--- a/sorc/fre-nctools.fd/tools/make_hgrid/CMakeLists.txt
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/CMakeLists.txt
@@ -5,30 +5,21 @@ set(c_src
   create_lonlat_grid.c
   make_hgrid.c)
 
-set ( PROJECT_LINK_LIBS libshared_all.a )
-link_directories(${CMAKE_CURRENT_BINARY_DIR}/../../shared_lib)
-include_directories(../../shared_lib)
-
 if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_C_FLAGS "-traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2")
-  set(CMAKE_C_FLAGS_DEBUG
-      "-O0"
-  )
+  set(CMAKE_C_FLAGS_DEBUG "-O0")
+    
 elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_C_FLAGS " ")
   set(CMAKE_C_FLAGS_RELEASE " ")
-  set(CMAKE_C_FLAGS_DEBUG " "
-  )
+  set(CMAKE_C_FLAGS_DEBUG " ")
 endif()
 
-set(exe_name make_hgrid)
-add_executable(${exe_name} ${c_src})
-target_include_directories(
-  ${exe_name} PRIVATE)
-target_link_libraries(
-  ${exe_name}
-  ${PROJECT_LINK_LIBS}
+add_executable(make_hgrid ${c_src})
+
+target_link_libraries(make_hgrid
+  shared_all
   NetCDF::NetCDF_C)
 
-install(TARGETS ${exe_name} RUNTIME DESTINATION exec)
+install(TARGETS make_hgrid RUNTIME DESTINATION exec)


### PR DESCRIPTION
I would test this out. The changes are simple, but I made these changes quickly and didn't have the various libraries to build with.

Link to target instead of .a

Make shared_all's headers public

Use target_compile_definitions

Use the target's name directly. Making it a variable is kind of redundant and doesn't really save anything. We did that in some of the other builds because we looped over target names and expanded them in code.

Prefer `target_include_directories` rather than `include_directories`. Working with targets instead of global function is generally preferred.
